### PR TITLE
Added Daily Status dashboard

### DIFF
--- a/src/main/java/io/quarkus/activity/ActivityResource.java
+++ b/src/main/java/io/quarkus/activity/ActivityResource.java
@@ -28,6 +28,9 @@ public class ActivityResource {
     GitHubService gitHubService;
 
     @Inject
+    GitHubDailyStatusService gitHubDailyStatusService;
+
+    @Inject
     Template activities;
 
     @Inject
@@ -35,6 +38,9 @@ public class ActivityResource {
 
     @Inject
     Template openPrQueue;
+
+    @Inject
+    Template dailyStatus;
 
     @GET
     @Produces(MediaType.TEXT_HTML)
@@ -64,6 +70,16 @@ public class ActivityResource {
         return openPrQueue.data(
                 "logins", gitHubService.getLogins(),
                 "organization", gitHubOpenPrQueueService.getOpenPrQueueInOrganization()
+        );
+    }
+
+    @GET
+    @Path("/daily-status")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getDailyStatus() throws IOException {
+        return dailyStatus.data(
+                "logins", gitHubService.getLogins(),
+                "repositories", gitHubDailyStatusService.getRepositoriesWithDailyStatus()
         );
     }
 }

--- a/src/main/java/io/quarkus/activity/GitHubDailyStatusService.java
+++ b/src/main/java/io/quarkus/activity/GitHubDailyStatusService.java
@@ -1,0 +1,19 @@
+package io.quarkus.activity;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import io.quarkus.activity.model.DailyStatusRepositories;
+
+@ApplicationScoped
+public class GitHubDailyStatusService {
+
+    @Inject
+    public DailyStatusRepositories dailyStatusRepositories;
+
+    public Map<String, String> getRepositoriesWithDailyStatus() {
+        return new TreeMap<>(dailyStatusRepositories.repositories());
+    }
+}

--- a/src/main/java/io/quarkus/activity/model/DailyStatusRepositories.java
+++ b/src/main/java/io/quarkus/activity/model/DailyStatusRepositories.java
@@ -1,0 +1,10 @@
+package io.quarkus.activity.model;
+
+import java.util.Map;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "activity.daily-status")
+public interface DailyStatusRepositories {
+    Map<String, String> repositories();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,9 @@ quarkus.kubernetes-client.trust-certs=true
 quarkus.openshift.labels."app"=gh-activity
 quarkus.openshift.route.expose=true
 quarkus.openshift.env.secrets=gh-activity-token
+
+activity.daily-status.repositories.beefy-scenarios=https://github.com/quarkus-qe/beefy-scenarios/actions/workflows/daily.yaml
+activity.daily-status.repositories.quarkus-extensions-combinations=https://github.com/quarkus-qe/quarkus-extensions-combinations/actions/workflows/daily.yml
+activity.daily-status.repositories.quarkus-startstop=https://github.com/quarkus-qe/quarkus-startstop/actions/workflows/ci.yaml
+activity.daily-status.repositories.quarkus-test-framework=https://github.com/quarkus-qe/quarkus-test-framework/actions/workflows/daily.yaml
+activity.daily-status.repositories.quarkus-test-suite=https://github.com/quarkus-qe/quarkus-test-suite/actions/workflows/daily.yaml

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -29,6 +29,10 @@
     <a class="header item" href="/open-pr-queue">
         Open PR Queue
     </a>
+
+    <a class="header item" href="/daily-status">
+        Daily Status
+    </a>
 </div>
 <div class="main-content">
     {#insert body /}

--- a/src/main/resources/templates/dailyStatus.html
+++ b/src/main/resources/templates/dailyStatus.html
@@ -1,0 +1,12 @@
+{#include base}
+{#title}Daily Status{/title}
+
+{#body}
+<div class="ui main container">
+    {#for entry in repositories}
+    <h2>{entry.key}</h2>
+    <a href="{entry.value}"><img src="{entry.value}/badge.svg" alt="{entry.key}"></a>
+    {/for}
+</div>
+{/body}
+{/include}


### PR DESCRIPTION
At the moment, the Daily Status will print the statuses of some Quarkus QE repositories.
But I foresee that more information will be added in the future and that's way I named it "Daily Status".
Fix https://github.com/quarkus-qe/gh-activity/issues/4