### PR TITLE
Add github dependant bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # For Quarkus Maven Plugin, updates are managed by Quarkus Bom dependency
+      - dependency-name: io.quarkus:quarkus-maven-plugin


### PR DESCRIPTION
Close #16

Add Github dependant bot in order to pick up the latest version of repo dependencies.  