### PR TITLE
Update Quarkus version and tracking info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.4.2</quarkus.platform.version>
     <surefire-plugin.version>3.1.0</surefire-plugin.version>
     <quarkus-prettytime.version>2.0.1</quarkus-prettytime.version>
   </properties>

--- a/src/main/java/io/quarkus/activity/github/GitHubService.java
+++ b/src/main/java/io/quarkus/activity/github/GitHubService.java
@@ -41,7 +41,7 @@ public class GitHubService {
 
     private final String token;
 
-    @ConfigProperty(name = "activity.logins", defaultValue = "rsvoboda,mjurc,pjgg,jsmrcka,fedinskiy,michalvavrik")
+    @ConfigProperty(name = "activity.logins", defaultValue = "rsvoboda,mjurc,jsmrcka,fedinskiy,michalvavrik,jedla97,mocenas")
     List<String> logins;
 
     @ConfigProperty(name = "activity.limit", defaultValue = "100")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,4 +15,4 @@ activity.daily-status.repositories.quarkus-extensions-combinations=https://githu
 activity.daily-status.repositories.quarkus-startstop=https://github.com/quarkus-qe/quarkus-startstop/actions/workflows/ci.yaml
 activity.daily-status.repositories.quarkus-test-framework=https://github.com/quarkus-qe/quarkus-test-framework/actions/workflows/daily.yaml
 activity.daily-status.repositories.quarkus-test-suite=https://github.com/quarkus-qe/quarkus-test-suite/actions/workflows/daily.yaml
-activity.daily-status.repositories.quarkus-test-suite-java-17=https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/workflows/ci.yml
+activity.daily-status.repositories.quarkus-jdkspecifics=https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/workflows/ci.yml


### PR DESCRIPTION
Hi, this PR updating the Quarkus version to the 3.4.2. Also Updating the default compiler version from java 11 to java 17. As the jdk specific TS now contains jdk 17 and jdk 21 the display name was changed from `java 17` to `jdk-specific`.

At last updating the logins to track.

Tested it locally and on Openshift both working.