### PR TITLE
Update and adapt GH app for new prod cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.4.2</quarkus.platform.version>
+    <quarkus.platform.version>3.8.2</quarkus.platform.version>
     <surefire-plugin.version>3.1.0</surefire-plugin.version>
     <quarkus-prettytime.version>2.0.1</quarkus-prettytime.version>
   </properties>
@@ -62,6 +62,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/io/quarkus/activity/graphql/GraphQLClient.java
+++ b/src/main/java/io/quarkus/activity/graphql/GraphQLClient.java
@@ -1,12 +1,16 @@
 package io.quarkus.activity.graphql;
 
 import io.vertx.core.json.JsonObject;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.core.HttpHeaders;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+@Retry(delay = 2, delayUnit = SECONDS)
 @RegisterRestClient(baseUri = "https://api.github.com/graphql")
 public interface GraphQLClient {
 

--- a/src/main/java/io/quarkus/activity/model/MonthlyStats.java
+++ b/src/main/java/io/quarkus/activity/model/MonthlyStats.java
@@ -1,9 +1,7 @@
 package io.quarkus.activity.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
-import org.graalvm.options.OptionDescriptors;
 
-import jakarta.ws.rs.core.AbstractMultivaluedMap;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,8 @@ quarkus.qute.suffixes=qute.html,qute.txt,html,txt,graphql
 
 quarkus.kubernetes-client.trust-certs=true
 quarkus.openshift.labels."app"=gh-activity
+quarkus.openshift.labels.shard=internal
+quarkus.openshift.labels.type=sharded
 quarkus.openshift.route.expose=true
 quarkus.openshift.env.secrets=gh-activity-token
 


### PR DESCRIPTION
- I needed to use our app in new prod cluster that seems to have stricter egress timeouts, so I couldn't manage to make `monthly-stats` work without repeat when request fails (either throttling or timeouts, not sure)
- We need to use `Deployment` and not `DeploymentConfig`, hence Quarkus bump
- My route needs to use internal shard, so I added label here for covenience
- compilation failed over `org.graalvm.options.OptionDescriptors`, not sure how it could have worked before?