### PR TITLE
Restrict access to app using OIDC extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,43 @@ For example, you can set the logins with a system property when starting the app
 -Dactivity.logins=qe-user-name-1,qe-user-name-2
 ```
 
+## Secure the application
+
+By default, the application only grants access to authenticated users with role `quarkus-qe`.
+Quarkus SecurityIdentity roles are mapped from access token claim `realm_access/roles`.
+If you use this application locally, you can disable security with following configuration property:
+
+```
+activity.security.enabled=false
+```
+
+As always, you can set this configuration property as a system property like this:
+
+```
+-Dactivity.security.enabled=false
+```
+
+## Configure OIDC extension
+
+Following 3 configuration properties must be set:
+
+```
+quarkus.oidc.auth-server-url=https://your-auth-server/auth/realms/your-realm
+quarkus.oidc.client-id=your-client-id
+quarkus.oidc.credentials.secret=your-client-secret
+```
+
 ## Running the application in dev mode
 
 You can run your application in dev mode that enables live coding using:
 ```shell script
 mvn compile quarkus:dev
+```
+
+By default, the security is disabled in DEV mode, however you can enable it like this:
+
+```shell script
+mvn compile quarkus:dev -Dactivity.security.enabled=true
 ```
 
 > **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
@@ -72,3 +104,13 @@ stringData:
 
 Deploy the secret using `oc create -f secret.yaml` command, update it using `oc replace -f secret.yaml` command. 
 
+If the `activity.security.enabled` configuration key is set to true, an OIDC client secret must be provided.
+Please create the secret called `gh-activity-oidc-client-secret` using same steps as described above.
+The `stringData` should look like this: 
+```
+OIDC_CLIENT_SECRET: your-client-secret
+OIDC_CLIENT_ID: your-client-id
+```
+
+Please note that if you want OpenShift route to be exposed for you, just set `quarkus.openshift.route.expose=true` inside the `application.properties` file.
+It's disabled by default as we create route with the `oc` command line tool.

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-oidc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,37 @@
 quarkus.qute.content-types.graphql=application/graphql
 quarkus.qute.suffixes=qute.html,qute.txt,html,txt,graphql
 
+activity.logins=${ACTIVITY_LOGINS:}
+activity.security.enabled=true
+
+quarkus.http.auth.permission.roles.policy=roles-policy
+quarkus.http.auth.permission.roles.paths=*
+quarkus.http.auth.permission.roles.enabled=${activity.security.enabled}
+# restrict access to identities with 'quarkus-qe' role
+quarkus.http.auth.policy.roles-policy.roles-allowed=quarkus-qe
+
+quarkus.oidc.enabled=${activity.security.enabled}
+quarkus.oidc.application-type=web-app
+quarkus.oidc.auth-server-url=${oidc-server-url:}
+quarkus.oidc.authentication.force-redirect-https-scheme=true
+quarkus.oidc.roles.source=accesstoken
+# if access token contains claim 'realm_access' with 'roles' JSON ARRAY
+# map it to the SecurityIdentity roles
+quarkus.oidc.roles.role-claim-path=realm_access/roles
+
+quarkus.oidc.client-id=${OIDC_CLIENT_ID:}
+quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:}
+
 %dev.activity.limit=5
 %dev.activity.logins=rsvoboda,mjurc
 %dev.activity.start=2021-01-01
+%dev.activity.security.enabled=false
 
 quarkus.kubernetes-client.trust-certs=true
 quarkus.openshift.labels."app"=gh-activity
 quarkus.openshift.labels.shard=internal
 quarkus.openshift.labels.type=sharded
-quarkus.openshift.route.expose=true
-quarkus.openshift.env.secrets=gh-activity-token
+quarkus.openshift.env.secrets=gh-activity-token,gh-activity-oidc-client-secret
 
 activity.daily-status.repositories.beefy-scenarios=https://github.com/quarkus-qe/beefy-scenarios/actions/workflows/daily.yaml
 activity.daily-status.repositories.quarkus-extensions-combinations=https://github.com/quarkus-qe/quarkus-extensions-combinations/actions/workflows/daily.yml


### PR DESCRIPTION
Restrict access to the GitHub activity app to authenticated users with `quarkus-qe` role. From now on, we only use secured routes configured manually, so that we don't need to create certificate and key every time we update this app.