### PR TITLE
Liveness probe for GraphQL client and additional colors for monthly stats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/io/quarkus/activity/GitHubOpenPrQueueService.java
+++ b/src/main/java/io/quarkus/activity/GitHubOpenPrQueueService.java
@@ -1,8 +1,8 @@
 package io.quarkus.activity;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -45,5 +45,9 @@ public class GitHubOpenPrQueueService {
 
     private OpenPullRequestsQueueByRepositories buildOpenPrQueueInOrganization() throws IOException {
         return gitHubService.getOpenPrQueueInOrganization(quarkusQeOrganization);
+    }
+
+    public synchronized Optional<LocalDateTime> getLastUpdated() {
+        return Optional.ofNullable(openPrQueueInOrganization).map(queue -> queue.updated);
     }
 }

--- a/src/main/java/io/quarkus/activity/HangCheck.java
+++ b/src/main/java/io/quarkus/activity/HangCheck.java
@@ -1,0 +1,41 @@
+package io.quarkus.activity;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Liveness;
+
+import java.time.LocalDateTime;
+
+@ApplicationScoped
+@Liveness
+/*
+  GraphQL client may stop to retrieve data properly (https://github.com/quarkusio/quarkus/issues/42029),
+  but restarting the app solves the problem.
+
+  This class creates a liveness endpoint and checks, that PR queue was updated at least two hours ago.
+  If it wasn't (ie last 12 requests failed), the next liveness probe will fail and the pod restarted
+ */
+public class HangCheck implements HealthCheck {
+
+    @Inject
+    GitHubOpenPrQueueService prService;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.named("GraphQL updates check");
+        LocalDateTime twoHoursAgo = LocalDateTime.now().minusHours(2);
+
+        builder.up();
+        prService.getLastUpdated()
+                .filter(lastUpdated -> lastUpdated.isBefore(twoHoursAgo))
+                .ifPresent(lastUpdated -> {
+                    builder.down();
+                    builder.withData("lastUpdate", lastUpdated.toString());
+                });
+
+        return builder.build();
+    }
+}

--- a/src/main/java/io/quarkus/activity/graphql/GraphQLClient.java
+++ b/src/main/java/io/quarkus/activity/graphql/GraphQLClient.java
@@ -1,6 +1,7 @@
 package io.quarkus.activity.graphql;
 
 import io.vertx.core.json.JsonObject;
+import jakarta.inject.Singleton;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -12,6 +13,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 @Retry(delay = 2, delayUnit = SECONDS)
 @RegisterRestClient(baseUri = "https://api.github.com/graphql")
+@Singleton
 public interface GraphQLClient {
 
     @POST

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,11 @@ quarkus.http.auth.permission.roles.enabled=${activity.security.enabled}
 # restrict access to identities with 'quarkus-qe' role
 quarkus.http.auth.policy.roles-policy.roles-allowed=quarkus-qe
 
+#Permit Kubernetest/OCP to access health endpoints without authorisation
+quarkus.http.auth.permission.probes.paths=/q/health/*
+quarkus.http.auth.permission.probes.policy=permit
+quarkus.http.auth.permission.probes.methods=GET
+
 quarkus.oidc.enabled=${activity.security.enabled}
 quarkus.oidc.application-type=web-app
 quarkus.oidc.auth-server-url=${oidc-server-url:}

--- a/src/main/resources/templates/monthlyStats.html
+++ b/src/main/resources/templates/monthlyStats.html
@@ -252,6 +252,7 @@
 				}
 			}
 			function getColor(index) {
+			    // there are currently 8 of us, +1 for a backup
 			    if (index == 0) { return 'rgba(255, 99, 132, 0.8)'}
 			    if (index == 1) { return 'rgba(255, 159, 64, 0.8)'}
 			    if (index == 2) { return 'rgba(255, 205, 86, 0.8)'}
@@ -259,6 +260,8 @@
 			    if (index == 4) { return 'rgba(54, 162, 245, 0.8)'}
 			    if (index == 5) { return 'rgba(153, 102, 255, 0.8)'}
 			    if (index == 6) { return 'rgba(191, 201, 202, 0.8)'}
+			    if (index == 7) { return 'rgba(29, 191, 58, 0.8)'}
+			    if (index == 8) { return 'rgba(1, 1, 1, 0.8)'}
                 var letters = '0123456789ABCDEF'.split('');
                 var color = '#';
                 for (var i = 0; i < 6; i++ ) {


### PR DESCRIPTION
1. Adds a liveness probe to restart the app if GraphQL client is stuck
2. Adds more fixed colors for monthly stats, so certain @fedinskiy will not be shown in 5 different ways on the same page :)