### PR TITLE
Avoid waiting for the data initialization

### DIFF
--- a/src/main/java/io/quarkus/activity/GitHubActivitiesService.java
+++ b/src/main/java/io/quarkus/activity/GitHubActivitiesService.java
@@ -31,16 +31,7 @@ public class GitHubActivitiesService {
     }
 
     public List<GitHubActivities> getGitHubActivities() throws IOException {
-        List<GitHubActivities> localGhActivities = ghActivities;
-        if (localGhActivities == null) {
-            synchronized (this) {
-                localGhActivities = ghActivities;
-                if (ghActivities == null) {
-                    ghActivities = localGhActivities = buildGitHubActivities();
-                }
-            }
-        }
-        return localGhActivities;
+        return ghActivities == null ? new ArrayList<>() : ghActivities;
     }
 
     // Call this method after `getGitHubActivities`

--- a/src/main/java/io/quarkus/activity/GitHubMonthlyStatsService.java
+++ b/src/main/java/io/quarkus/activity/GitHubMonthlyStatsService.java
@@ -27,16 +27,7 @@ public class GitHubMonthlyStatsService {
     }
 
     public MonthlyStats getMonthlyStats() throws IOException {
-        MonthlyStats localStats = monthlyStats;
-        if (localStats == null) {
-            synchronized (this) {
-                localStats = monthlyStats;
-                if (monthlyStats == null) {
-                    monthlyStats = localStats = buildMonthlyStats();
-                }
-            }
-        }
-        return localStats;
+        return monthlyStats == null ? new MonthlyStats() : monthlyStats;
     }
 
     private MonthlyStats buildMonthlyStats() throws IOException {

--- a/src/main/java/io/quarkus/activity/GitHubOpenPrQueueService.java
+++ b/src/main/java/io/quarkus/activity/GitHubOpenPrQueueService.java
@@ -30,17 +30,7 @@ public class GitHubOpenPrQueueService {
     }
 
     public OpenPullRequestsQueueByRepositories getOpenPrQueueInOrganization() throws IOException {
-        OpenPullRequestsQueueByRepositories localStats = openPrQueueInOrganization;
-        if (localStats == null) {
-            synchronized (this) {
-                localStats = openPrQueueInOrganization;
-                if (openPrQueueInOrganization == null) {
-                    openPrQueueInOrganization = localStats = buildOpenPrQueueInOrganization();
-                }
-            }
-        }
-
-        return localStats;
+        return openPrQueueInOrganization == null ? new OpenPullRequestsQueueByRepositories() : openPrQueueInOrganization;
     }
 
     private OpenPullRequestsQueueByRepositories buildOpenPrQueueInOrganization() throws IOException {


### PR DESCRIPTION
Avoid waiting for the data initialization

Return an empty set of data in that case
Scheduled task execution begins right after the application starts, custom init logic is not required now, we needed that when the application was developed

Details: https://github.com/quarkusio/quarkus/blob/3.20.0/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduled.java#L139